### PR TITLE
Fix hardcoded tags

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -398,9 +398,7 @@ resource "aws_cloudfront_distribution" "s3_distribution_ip" {
     }
   }
 
-  tags = {
-    Environment = "production"
-  }
+  tags = var.tags
 
   viewer_certificate {
     cloudfront_default_certificate = true


### PR DESCRIPTION
Removed tag Environment from module.data-qa.aws_cloudfront_distribution.s3_distribution_ip[0]

 Hardcoded ends can raise the Terraform issue similar to:
 ```
 │ Error: "tags" are identical to those in the "default_tags" configuration block of the provider: please de-duplicate and try again
│ 
│   with module.data-qa.aws_cloudfront_distribution.s3_distribution_ip[0],
│   on .terraform/modules/data-qa/cloudfront.tf line 277, in resource "aws_cloudfront_distribution" "s3_distribution_ip":
│  277: resource "aws_cloudfront_distribution" "s3_distribution_ip" {
```