### PR TITLE
[MAINTENANCE] Changes to run jira events only for failed tests suites

### DIFF
--- a/functions/report_push/push_data_report.py
+++ b/functions/report_push/push_data_report.py
@@ -85,7 +85,7 @@ def handler(event, context):
         only_failed = True
         print(f"Can't find only_failed param for {run_name}")
 
-    if autobug and failed > 0:
+    if autobug and failed:
         jira_project_key = os.environ['JIRA_PROJECT_KEY']
         auth_in_jira()
         created_bug_count, bug_name = create_jira_bugs_from_allure_result(

--- a/functions/report_push/push_data_report.py
+++ b/functions/report_push/push_data_report.py
@@ -85,7 +85,7 @@ def handler(event, context):
         only_failed = True
         print(f"Can't find only_failed param for {run_name}")
 
-    if autobug:
+    if autobug & failed > 0:
         jira_project_key = os.environ['JIRA_PROJECT_KEY']
         auth_in_jira()
         created_bug_count, bug_name = create_jira_bugs_from_allure_result(

--- a/functions/report_push/push_data_report.py
+++ b/functions/report_push/push_data_report.py
@@ -85,7 +85,7 @@ def handler(event, context):
         only_failed = True
         print(f"Can't find only_failed param for {run_name}")
 
-    if autobug & failed > 0:
+    if autobug and failed > 0:
         jira_project_key = os.environ['JIRA_PROJECT_KEY']
         auth_in_jira()
         created_bug_count, bug_name = create_jira_bugs_from_allure_result(


### PR DESCRIPTION
Adding a check for the status of the run before starting the check of all allure reports for failed tests and requests in jira