### PR TITLE
[BUGFIX] changed threshold calculation

### DIFF
--- a/functions/data_test/profiling.py
+++ b/functions/data_test/profiling.py
@@ -100,9 +100,9 @@ def expectations_z_score(name, summary, batch, *args):
     std = summary["std"]
     maximum = summary["max"]
     threshold = (maximum - mean) / std
-    if std != 0:
+    if std:
         batch.expect_column_value_z_scores_to_be_less_than(
-            column=name, threshold=threshold, double_sided=True)
+            column=name, threshold=threshold+0.005, double_sided=False)
     return name, summary, batch
 
 

--- a/functions/data_test/profiling.py
+++ b/functions/data_test/profiling.py
@@ -99,10 +99,11 @@ def expectations_z_score(name, summary, batch, *args):
     mean = summary["mean"]
     std = summary["std"]
     maximum = summary["max"]
+    significance_level = 0.005
     threshold = (maximum - mean) / std
     if std:
         batch.expect_column_value_z_scores_to_be_less_than(
-            column=name, threshold=threshold+0.005, double_sided=False)
+            column=name, threshold=threshold+significance_level, double_sided=False)
     return name, summary, batch
 
 


### PR DESCRIPTION
GX use strict comparison for threshold, so we need to add significance level param to avoid false failed on max values
https://en.wikipedia.org/wiki/Statistical_significance
double_side=false because gx not allowed to use min and max, only max and it's also throw false failed tests